### PR TITLE
TST: make pytest work for doctests

### DIFF
--- a/dipp/__init__.py
+++ b/dipp/__init__.py
@@ -10,9 +10,11 @@
 
 __version__ = '0.1.0.dev0'
 
-__all__ = ()
+__all__ = ('util',)
 
-# We keep this file empty to keep the namespaces of the subpackages separate.
-# This allows users to only install selected frameworks and still be able
-# to import the relevant subpackages without getting ImportError due to
-# a missing module.
+from . import util
+
+# We don't add any of the Deep-Learning-framework-specific subpackages here
+# to keep their namespaces separate. This allows users to only install
+# selected frameworks and still be able to import the relevant subpackages
+# without getting ImportError due to a missing module.

--- a/dipp/util/pytest_plugins.py
+++ b/dipp/util/pytest_plugins.py
@@ -15,7 +15,7 @@ import os
 
 import dipp
 try:
-    import dipp.pytorch
+    import torch
 except ImportError:
     PYTORCH_AVAILABLE = False
 else:
@@ -38,9 +38,14 @@ except ImportError:
 
 @fixture(autouse=True)
 def add_doctest_modules(doctest_namespace):
+    """Make some modules available by default in doctests."""
     doctest_namespace['np'] = np
     if PYTORCH_AVAILABLE:
+        from torch import autograd, nn
         doctest_namespace['pytorch'] = dipp.pytorch
+        doctest_namespace['torch'] = torch
+        doctest_namespace['autograd'] = autograd
+        doctest_namespace['nn'] = nn
 
 
 # --- Ignored tests due to missing modules --- #


### PR DESCRIPTION
Some small changes to make `pytest` basically work. Skips the tests if `torch` is not found, and runs them when it is there (and they pass). We can go from here.